### PR TITLE
Change version matching due to new regex

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# v0.2.4#
+- [BUG] Support '.avi-on.com.v' urls at regex when getting versioning
+
 # v0.2.3#
 - [BUG] Support double nested controllers
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,11 +227,11 @@ Rest.prototype = {
     } else {
       var match = grab.exec(accept_header);
 
-      if (match && match[1]) {
-        if (match[1] !== '' && versions[ match[1] ] ) {
-          return match[1];
+      if (match && match[2]) {
+        if (match[2] !== '' && versions[ match[2] ] ) {
+          return match[2];
 
-        } else if (match[1] !== '' && versions[match[1]] === undefined && versions['*'] ) {
+        } else if (match[2] !== '' && versions[match[2]] === undefined && versions['*'] ) {
           return '*';
 
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-routes-controllers",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Creates routes for the controllers",
   "dependencies": {
     "express": "3.4.8",
@@ -23,10 +23,12 @@
     "name": "Daniel Nicolas Mule",
     "email": "pola88@gmail.com"
   },
-  "contributors": [{
-    "name": "blanchma",
-    "email": "tute.unique@gmail.com"
-  }],
+  "contributors": [
+    {
+      "name": "blanchma",
+      "email": "tute.unique@gmail.com"
+    }
+  ],
   "keywords": [
     "express",
     "rest",

--- a/spec/load_controllers.js
+++ b/spec/load_controllers.js
@@ -3,7 +3,7 @@ var Rest = require('../lib'),
 
 var rest = new Rest( { controllers: path.join(__dirname, '/controllers'),
                       versioning: { header: 'Accept',
-                                    grab: /.*application\/vnd.test.v(\d+)\+json/,
+                                    grab: /.*application\/vnd.test(.com)?.v(\d+)\+json/,
                                     error: '405' }
                     } );
 


### PR DESCRIPTION
Due to the new regex (same we are using at app_version), we need to change the match subindex where it would be parsed. The new regex match is as follows
```js
/.avi-on(.com)?.v?(\d+)/
```

While the old one was:
```js
/.avi-on.v?(\d+)/
```
